### PR TITLE
фикс мета

### DIFF
--- a/Resources/Prototypes/Reagents/narcotics.yml
+++ b/Resources/Prototypes/Reagents/narcotics.yml
@@ -14,15 +14,18 @@
       - !type:HealthChange
         damage:
           types:
-            Poison: 0.75
+            Poison: 1
+            Asphyxiation: 1
+            Cellular: 0.5
       - !type:HealthChange
         conditions:
         - !type:ReagentThreshold
           min: 30
         damage:
           types:
-            Poison: 2 # this is added to the base damage of the meth.
-            Asphyxiation: 2
+            Poison: 8 # this is added to the base damage of the meth.
+            Asphyxiation: 10
+            Cellular: 5
     Narcotic:
       effects:
       - !type:MovespeedModifier
@@ -54,6 +57,66 @@
         conditions:
         - !type:ReagentThreshold
           min: 20
+      - !type:HealthChange
+        conditions:
+        - !type:ReagentThreshold # урон от дило
+          reagent: Dylovene
+          min: 1
+        damage:
+          types:
+            Cellular: 0.5
+            Asphyxiation: 1
+            Poison: 2
+      - !type:HealthChange
+        conditions:
+        - !type:ReagentThreshold
+          reagent: Dylovene
+          min: 10
+        damage:
+          types:
+            Cellular: 1
+            Asphyxiation: 1.5
+            Poison: 2.5
+      - !type:HealthChange
+        conditions:
+        - !type:ReagentThreshold
+          reagent: Dylovene
+          min: 15
+        damage:
+          types:
+            Cellular: 3
+            Asphyxiation: 3
+            Poison: 3
+      - !type:HealthChange
+        conditions:
+        - !type:ReagentThreshold # урон от дило
+          reagent: Omnizine
+          min: 1
+        damage:
+          types:
+            Cellular: 0.5
+            Asphyxiation: 1
+            Poison: 2
+      - !type:HealthChange
+        conditions:
+        - !type:ReagentThreshold
+          reagent: Omnizine
+          min: 10
+        damage:
+          types:
+            Cellular: 1
+            Asphyxiation: 1.5
+            Poison: 2.5
+      - !type:HealthChange
+        conditions:
+        - !type:ReagentThreshold
+          reagent: Omnizine
+          min: 15
+        damage:
+          types:
+            Cellular: 3
+            Asphyxiation: 3
+            Poison: 3
 
 - type: reagent
   id: Ephedrine

--- a/Resources/Prototypes/_Sunrise/Recipes/Reactions/medicine.yml
+++ b/Resources/Prototypes/_Sunrise/Recipes/Reactions/medicine.yml
@@ -42,16 +42,6 @@
     Celliminol: 5
 
 - type: reaction
-  id: Dylomet
-  reactants:
-    Dylovene:
-      amount: 1
-    Desoxyephedrine:
-      amount: 1
-  products:
-    Dylomet: 1
-
-- type: reaction
   id: StableMutagen
   reactants:
     Phalanximine:


### PR DESCRIPTION
<!-- Пожалуйста прочитайте эту статью перед тем как выложить PR, чтобы избежать лишних правок в процессе осмотра: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- Текст в стрелочках является комментариями - они не будут видны в вашем PR. -->

## Кратное описание
Изменить наносимый урон дезоксиэфедрином.

## По какой причине
В игре существовал яд под названием диломет. Он был довольно сильным ядом и простым в крафте, но самое главное — он устранял существование связки диловен + дезоксиэфедрин. Это изменение было призвано оставить эту связку, но сделать у дило + мета сильные побочные эффекты, которые не позволят игрокам использовать её во время боёв.

## Медиа(Видео/Скриншоты)
<!--
Если ваш PR содержит внутриигровые изменения вы обязаны предоставить скриншоты/видео изменений.
-->

**Changelog**
<!--
Если нужно чтобы игроки узнали об изменениях сделанных в данном PR, укажите их используя шаблон вне комментария.
Кратко и информативно.  -->

:cl: blad_bochar
- tweak: Изменено урон который наносоит дезоксиэфедрин.

