### PR TITLE
Сокращение истощения в семь раз

### DIFF
--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -205,7 +205,7 @@
               Toxin: -4
             #Sunrise-Start
             types:
-             Mangleness: -0.071
+             Mangleness: -0.5
             #Sunrise-End
 
 - type: reagent
@@ -855,7 +855,7 @@
             Heat: -0.33
             Shock: -0.33
             Cold: -0.33
-            Mangleness: -0.007 #Sunrise-Edit
+            Mangleness: -0.05 #Sunrise-Edit
 
 - type: reagent
   id: Lipozine
@@ -888,7 +888,7 @@
       - !type:HealthChange
         damage:
           types:
-            Mangleness: -0.029
+            Mangleness: -0.2
       #Sunrise-End
       - !type:EvenHealthChange
         damage:
@@ -1223,7 +1223,7 @@
             Heat: -0.5
             Shock: -0.5
             Cold: -0.5
-            Mangleness: -0.014
+            Mangleness: -0.1
             # Sunrise-End
   reactiveEffects:
     Unholy:
@@ -1386,7 +1386,7 @@
               Burn: -5
             types:
               Poison: -2
-              Mangleness: -0.071 #Sunrise-Edit
+              Mangleness: -0.5 #Sunrise-Edit
 
 - type: reagent
   id : Aloxadone


### PR DESCRIPTION
Reduced Mangleness damage values across multiple medicine reagents in medicine.yml for better balance. These changes affect healing and damage interactions related to Mangleness, likely to fine-tune gameplay effects.

(это было сделано ИИ описание)

<!-- Пожалуйста прочитайте эту статью перед тем как выложить PR, чтобы избежать лишних правок в процессе осмотра: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- Текст в стрелочках является комментариями - они не будут видны в вашем PR. -->

## Кратное описание
<!-- Что вы предлагаете изменить с помощью своего PR? -->

## По какой причине
<!-- В чём причина добавления этих изменений? Ссылки на Дискуссии, а так-же Баг-Репорты указывать здесь. Пожалуйста опишите как это изменит игровой баланс. -->

## Медиа(Видео/Скриншоты)
<!--
Если ваш PR содержит внутриигровые изменения вы обязаны предоставить скриншоты/видео изменений.
-->

**Changelog**
:cl: Alternativ_
- tweak: Истощение сокращено в семь раз. 
