### PR TITLE
BloodCultSystem.Actions.cs

### DIFF
--- a/Content.Server/_Sunrise/BloodCult/Runes/Systems/BloodCultSystem.Actions.cs
+++ b/Content.Server/_Sunrise/BloodCult/Runes/Systems/BloodCultSystem.Actions.cs
@@ -332,7 +332,7 @@ namespace Content.Server._Sunrise.BloodCult.Runes.Systems
             if (!TryComp<BloodstreamComponent>(args.Performer, out _))
                 return;
 
-            if (!_statusEffectsSystem.HasStatusEffect(args.Target, "Stun"))
+            if (!_statusEffectsSystem.HasStatusEffect(args.Target, "Paralyze"))
             {
                 _popupSystem.PopupEntity("Цель не оглушена", uid, uid);
                 return;


### PR DESCRIPTION
блять теневые футы или путы должны пахать

<!-- Пожалуйста прочитайте эту статью перед тем как выложить PR, чтобы избежать лишних правок в процессе осмотра: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- Текст в стрелочках является комментариями - они не будут видны в вашем PR. -->

## Кратное описание
<!-- Отладка работы теневых пут? -->

## По какой причине
<!-- доработал то что не работало, мне указали теневые путы как сам багрепорт. -->

## Медиа(Видео/Скриншоты)
<!--
-.
-->

**Changelog**
<!--
Заменено слово "Stun" на "Paralyze" в методе OnShadowShackles для корректной проверки статуса эффекта.

Описание:
Ранее проверка выглядела так:
if (!_statusEffectsSystem.HasStatusEffect(args.Target, "Stun"))
Стало:
if (!_statusEffectsSystem.HasStatusEffect(args.Target, "Paralyze"))

Логика исправления:
Текущая реализация накладывает статус "Paralyze" через вызов OnStunTarget, однако условие проверяло наличие эффекта "Stun". Это приводило к тому, что "Теневые путы" применялись даже к врагам, уже находящимся под действием "Paralyze", но не "Stun". В результате враги, которых парализовали этим методом, получали неверное поведение — повторное наложение эффекта не блокировалось. Теперь проверка будет корретной, и "Теневые путы" не будут накладываться на уже парализованных целей, как это задумывалось по логике механики..

:cl: VigersRay
- add: Добавлено веселье.
- remove: Удалено веселье.
- tweak: Изменено веселье.
- fix: Исправлено веселье.
-->
