### PR TITLE
Меняем новые тазеры на ниш тип патронов

### DIFF
--- a/Resources/Prototypes/_Starlight/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -43,7 +43,7 @@
       visualState: disable
       magState: disable
       heldPrefix: disable4
-    - proto: TaserBolt
+    - proto: BulletTaserSunrise
       fireCost: 166
       visualState: stun
       magState: stun
@@ -81,14 +81,14 @@
     autoRechargePauseTime: 10
   - type: HitscanBatteryAmmoProvider
     proto: DisablerBolt
-    fireCost: 50
+    fireCost: 100
   - type: BatteryWeaponFireModes
     fireModes:
     - proto: DisablerBolt
-      fireCost: 50
+      fireCost: 100
       magState: disable
-    - proto: TaserBolt
-      fireCost: 166
+    - proto: BulletTaserSunrise
+      fireCost: 200
       magState: stun
       conditions:
       - !type:AlertLevelCondition
@@ -99,7 +99,7 @@
         - red
         - gamma
     - proto: RedLaserBeam
-      fireCost: 66.6
+      fireCost: 250
       magState: lethal
       conditions:
       - !type:AlertLevelCondition
@@ -343,7 +343,7 @@
     fireCost: 100
   - type: BatteryWeaponFireModes
     fireModes:
-    - proto: TaserBolt
+    - proto: BulletTaserSunrise
       fireCost: 100
       magState: stun
     - proto: RedLaserBeam


### PR DESCRIPTION
<!-- Пожалуйста прочитайте эту статью перед тем как выложить PR, чтобы избежать лишних правок в процессе осмотра: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- Текст в стрелочках является комментариями - они не будут видны в вашем PR. -->

## Кратное описание
<!-- Что вы предлагаете изменить с помощью своего PR? -->
Адаптируем новые тазеры подстать текущим

## По какой причине
<!-- В чём причина добавления этих изменений? Ссылки на Дискуссии, а так-же Баг-Репорты указывать здесь. Пожалуйста опишите как это изменит игровой баланс. -->

## Медиа(Видео/Скриншоты)
<!--
Если ваш PR содержит внутриигровые изменения вы обязаны предоставить скриншоты/видео изменений.
-->

**Changelog**

:cl: Kaiten
- tweak: Новые тазеры (Доминатор и прочие) используют Санрайзовский снаряд и больше не роняют сразу же при попадании
- tweak: Доминатор теперь имеет больший расход энергии на стрельбу тазерными и лазерными снарядами.

