### PR TITLE
Камбек культа плоти после нерфов

### DIFF
--- a/Resources/Prototypes/_Sunrise/FleshCult/Actions/flesh_cultist.yml
+++ b/Resources/Prototypes/_Sunrise/FleshCult/Actions/flesh_cultist.yml
@@ -37,7 +37,7 @@
   - type: Action
     icon: _Sunrise/FleshCult/Interface/Actions/fleshCultistAdrenalin.png
     itemIconStyle: NoItem
-    useDelay: 60
+    useDelay: 90 # Fish-edit
     checkCanInteract: false
   - type: InstantAction
     event: !type:FleshCultistAdrenalinActionEvent
@@ -82,10 +82,10 @@
   - type: Action
     icon: _Sunrise/FleshCult/Interface/Actions/fleshThrowHugger.png
     itemIconStyle: NoItem
-    useDelay: 60
+    useDelay: 180 # Fish-edit
     checkCanInteract: false
   - type: TargetAction
-    range: 200
+    range: 300 # Fish-edit
   - type: WorldTargetAction
     event: !type:FleshCultistThrowHuggerActionEvent
 

--- a/Resources/Prototypes/_Sunrise/FleshCult/body_mods.yml
+++ b/Resources/Prototypes/_Sunrise/FleshCult/body_mods.yml
@@ -7,8 +7,8 @@
   suffix: Flesh Cult
   components:
   - type: ClothingSpeedModifier
-    walkModifier: 1.2
-    sprintModifier: 1.25
+    walkModifier: 1.15 # Fish-edit
+    sprintModifier: 1.2 # Fish-edit
   - type: Sprite
     sprite: _Sunrise/FleshCult/FleshBodyMods/flesh_spider.rsi
   - type: Clothing
@@ -20,7 +20,7 @@
     footstepSoundCollection:
       collection: FootstepSpiderLegs
       params:
-        volume: 10
+        volume: 15 # Fish-edit
   - type: HideLayerClothing
     slots:
       - RFoot
@@ -46,10 +46,13 @@
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.5
-        Slash: 0.5
-        Piercing: 0.5
-        Heat: 0.7
+        # Fish-start
+        Blunt: 0.6
+        Slash: 0.6
+        Piercing: 0.6
+        Heat: 0.9
+        Caustic: 0.7
+        # Fish-end
   - type: ExplosionResistance
     damageCoefficient: 0.9
   - type: GroupExamine
@@ -78,7 +81,7 @@
         Blunt: 0.3
         Slash: 0.3
         Piercing: 0.3
-        Heat: 0.5
+        Heat: 0.6 # Fish-edit
   - type: ClothingSpeedModifier
     walkModifier: 0.85
     sprintModifier: 0.85

--- a/Resources/Prototypes/_Sunrise/FleshCult/hands_mods.yml
+++ b/Resources/Prototypes/_Sunrise/FleshCult/hands_mods.yml
@@ -74,7 +74,7 @@
       delay: 6
     - type: UseDelayOnMeleeHit
     - type: MeleeThrowOnHit
-      stunTime: 1.5
+      stunTime: 0 # Fish-edit
       activateOnThrown: true
       distance: 6
       speed: 7
@@ -82,8 +82,8 @@
       attackRate: 0.5
       damage:
         types:
-          Blunt: 22
-          Structural: 44
+          Blunt: 25 # Fish-edit
+          Structural: 35 # Fish-edit
       soundHit:
         collection: MetalThud
     - type: Item
@@ -115,7 +115,8 @@
       attackRate: 1.2
       damage:
         types:
-          Piercing: 19
+          Piercing: 9 # Fish-edit
+          Slash: 10 # Fish-edit
       resistanceBypass: true
       soundHit:
           path: /Audio/Weapons/bladeslice.ogg

--- a/Resources/Prototypes/_Sunrise/FleshCult/projectiles.yml
+++ b/Resources/Prototypes/_Sunrise/FleshCult/projectiles.yml
@@ -36,5 +36,5 @@
     impactEffect: BulletImpactEffectKinetic
     damage:
       types:
-        Piercing: 15
+        Piercing: 12 # Fish-edit
 

--- a/Resources/Prototypes/_Sunrise/secret_weights.yml
+++ b/Resources/Prototypes/_Sunrise/secret_weights.yml
@@ -10,9 +10,10 @@
 - type: weightedRandom
   id: FishSecret
   weights:
-    Traitor: 0.2
-    BloodCult: 0.2
-    AssaultOps: 0.1
-    Revolutionary: 0.2
-    Nukeops: 0.2
-    Zombie: 0.1
+    Traitor: 0.1538
+    BloodCult: 0.1538
+    FleshCult: 0.1538
+    AssaultOps: 0.0769
+    Revolutionary: 0.1538
+    Nukeops: 0.1538
+    Zombie: 0.0769


### PR DESCRIPTION
<!-- Пожалуйста прочитайте эту статью перед тем как выложить PR, чтобы избежать лишних правок в процессе осмотра: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- Текст в стрелочках является комментариями - они не будут видны в вашем PR. -->

## Кратное описание
<!-- Что вы предлагаете изменить с помощью своего PR? -->

## По какой причине
<!-- В чём причина добавления этих изменений? Ссылки на Дискуссии, а так-же Баг-Репорты указывать здесь. Пожалуйста опишите как это изменит игровой баланс. -->

## Медиа(Видео/Скриншоты)
<!--
Если ваш PR содержит внутриигровые изменения вы обязаны предоставить скриншоты/видео изменений.
<img width="882" height="705" alt="image" src="https://github.com/user-attachments/assets/90e0bfd7-e80a-474f-9854-4155894c1d19" />
<img width="894" height="691" alt="image" src="https://github.com/user-attachments/assets/a50a78f1-12e8-4a6d-ac15-51a083c06ecd" />

-->

**Changelog**

:cl: Kaiten
- tweak: Бонус скорости от паучьих ног сокращён на 5% для бега и ходьбы (с 1.25 до 1.2 и 1.2 до 1.15).
- tweak: Паучьи ноги производят на 50% больше шума при ходьбе.
- tweak: Перезарядка способности Адреналин (дающая 10 Эфедрина культистам) увеличена с 60 до 90 секунд.
- tweak: У способности броска лицехвата увеличен радиус на 50% и увеличена перезарядка с 60 до 180 секунд (а то серверу плохо от спама).
- tweak: Защитные показатели обычной брони Культа плоти теперь эквивалентны скафандру СБ, но без замедления (защита уменьшена).
- tweak: Сопротивление огню у тяжелой брони Культа Плоти уменьшено с 50% до 40%.
- tweak: Кулак плоти больше не оглушает при попадании, но всё также откидывает ударом раз в 6 секунд (скорость его атаки не менялась и равна 1 удар раз в 2 секунды).
- tweak: Урон Кулака плоти изменён с 22 ушибов и 44 структурного до 25 ушибов и 35 структурного.
- tweak: Урон Клинка плоти изменён с 19 уколами на 10 порезов и 9 уколов.
- tweak: Урон Костяных пуль уменьшен с 15 уколов до 12 уколов.
