### PR TITLE
gazik

### DIFF
--- a/Resources/Prototypes/_Sunrise/Reagents/gases.yml
+++ b/Resources/Prototypes/_Sunrise/Reagents/gases.yml
@@ -178,16 +178,7 @@
         sprintSpeedModifier: 1.4
       - !type:MovespeedModifier
         walkSpeedModifier: 1.4
-        sprintSpeedModifier: 1.4
-      - !type:HealthChange
-        conditions:
-        - !type:ReagentThreshold
-          reagent: Nitrium
-          min: 0.5
-        ignoreResistances: true
-        damage:
-          types:
-            Mangleness: 0.5 #Fish-Edit
+        sprintSpeedModifier: 1.4 #Fish-Edit
       - !type:HealthChange
         conditions:
           - !type:ReagentThreshold


### PR DESCRIPTION
<!-- Пожалуйста прочитайте эту статью перед тем как выложить PR, чтобы избежать лишних правок в процессе осмотра: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- Текст в стрелочках является комментариями - они не будут видны в вашем PR. -->

## Кратное описание
нитра не наносит урон истощением

## По какой причине
станет юзабельной

## Медиа(Видео/Скриншоты)
<!--
Если ваш PR содержит внутриигровые изменения вы обязаны предоставить скриншоты/видео изменений.
-->

**Changelog**


:cl: onibus71
- tweak: нитриум больше не наносит урон истощением.
