### PR TITLE
Обнова рыбного секрета

### DIFF
--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -331,7 +331,7 @@
   parent: BaseGameRule
   components:
   - type: GameRule
-    minPlayers: 15
+    minPlayers: 35 # Fish-edit
     # Sunrise-Start
     delay:
       min: 900
@@ -448,7 +448,7 @@
   parent: BaseGameRule
   components:
   - type: GameRule
-    minPlayers: 20
+    minPlayers: 35 # Fish-edit
     delay:
       min: 600
       max: 900

--- a/Resources/Prototypes/_Fish/secret_weights.yml
+++ b/Resources/Prototypes/_Fish/secret_weights.yml
@@ -1,10 +1,10 @@
 - type: weightedRandom
   id: FishSecret
   weights:
-    Traitor: 0.1538
-    BloodCult: 0.1538
-    FleshCult: 0.1538
-    AssaultOps: 0.0769
-    Revolutionary: 0.1538
-    Nukeops: 0.1538
-    Zombie: 0.0769
+    Traitor: 0.030
+    BloodCult: 0.176
+    FleshCult: 0.176
+    AssaultOps: 0.176
+    Revolutionary: 0.176
+    Nukeops: 0.176
+    Zombie: 0.090


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

<!-- Текст в стрелочках является комментариями - они не будут видны в вашем PR. -->

## Кратное описание
<!-- Что вы предлагаете изменить с помощью своего PR? -->

## По какой причине
<!-- В чём причина добавления этих изменений? Ссылки на Дискуссии, а так-же Баг-Репорты указывать здесь. Пожалуйста опишите как это изменит игровой баланс. -->

## Медиа(Видео/Скриншоты)
<!--
Если ваш PR содержит внутриигровые изменения вы обязаны предоставить скриншоты/видео изменений.
-->

**Changelog**


:cl: Kaiten
- add: Пороги для мажоров повышены до 35 готовых игроков. Повышены шансы на мажоров при 35+ готовых игроках.

