### PR TITLE
DeltaP в CVars

### DIFF
--- a/Content.Server/Atmos/EntitySystems/DeltaPressureSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/DeltaPressureSystem.cs
@@ -25,7 +25,12 @@ public sealed partial class DeltaPressureSystem : SharedDeltaPressureSystem
         SubscribeLocalEvent<DeltaPressureComponent, ComponentInit>(OnComponentInit);
         SubscribeLocalEvent<DeltaPressureComponent, ComponentShutdown>(OnComponentShutdown);
         SubscribeLocalEvent<DeltaPressureComponent, GridUidChangedEvent>(OnGridChanged);
+
+        // Fish-edit - DeltaP override
+        AfterInit();
     }
+
+    partial void AfterInit(); // Fish-edit - DeltaP override
 
     private void OnComponentInit(Entity<DeltaPressureComponent> ent, ref ComponentInit args)
     {

--- a/Content.Server/_Fish/Atmos/DeltaPressureOverrideSystem.cs
+++ b/Content.Server/_Fish/Atmos/DeltaPressureOverrideSystem.cs
@@ -1,0 +1,67 @@
+using Content.Shared._Fish.FishCCVars;
+using Content.Shared.Atmos.Components;
+using Robust.Shared.Configuration;
+
+namespace Content.Server.Atmos.EntitySystems;
+
+public enum WindowID
+{
+    // Reinforced plasma windows
+    PlasmaReinforcedWindowDirectional,
+    ReinforcedPlasmaWindow,
+    ReinforcedPlasmaWindowDiagonal,
+
+    // Reinforced windows
+    WindowReinforcedDirectional,
+    ReinforcedWindow,
+    ReinforcedWindowDiagonal
+}
+
+// This system allows to override values from `deltapressure.yml` without modifying prototypes
+public partial class DeltaPressureSystem
+{
+    [Dependency] private readonly IConfigurationManager _cfg = default!;
+
+    private float _deltaPReinforcedPlasma;
+
+    private float _deltaPReinforced;
+
+    partial void AfterInit()
+    {
+        _cfg.OnValueChanged(FishCCVars.DeltaPReinforcedPlasma, (value) => _deltaPReinforcedPlasma = value, true);
+        _cfg.OnValueChanged(FishCCVars.DeltaPReinforced, (value) => _deltaPReinforced = value, true);
+
+        SubscribeLocalEvent<DeltaPressureComponent, ComponentStartup>(OnDeltaPressureComponentStartup);
+    }
+
+    private void OnDeltaPressureComponentStartup(Entity<DeltaPressureComponent> ent, ref ComponentStartup args)
+    {
+        Override(ent, ref args);
+    }
+
+    private bool Override(Entity<DeltaPressureComponent> ent, ref ComponentStartup args)
+    {
+        TryPrototype(ent, out var proto);
+
+        if (proto is null || !Enum.TryParse<WindowID>(proto.ID, out var windowProtoID))
+            return false;
+
+        return windowProtoID switch
+        {
+            WindowID.PlasmaReinforcedWindowDirectional
+                or WindowID.ReinforcedPlasmaWindow
+                or WindowID.ReinforcedPlasmaWindowDiagonal => SetMinPressure(ent, _deltaPReinforcedPlasma),
+            WindowID.WindowReinforcedDirectional
+                or WindowID.ReinforcedWindow
+                or WindowID.ReinforcedWindowDiagonal => SetMinPressure(ent, _deltaPReinforced),
+            _ => false,
+        };
+    }
+
+    private static bool SetMinPressure(Entity<DeltaPressureComponent> ent, float pressure)
+    {
+        ent.Comp.MinPressure = pressure;
+        ent.Comp.MinPressureDelta = pressure;
+        return true;
+    }
+}

--- a/Content.Shared/_Fish/FishCCVars/FishCCVars.Atmos.cs
+++ b/Content.Shared/_Fish/FishCCVars/FishCCVars.Atmos.cs
@@ -1,0 +1,17 @@
+using Robust.Shared;
+using Robust.Shared.Configuration;
+
+namespace Content.Shared._Fish.FishCCVars;
+
+
+public sealed partial class FishCCVars : CVars
+{
+    /// <summary>
+    /// DeltaP threshold overrides for pressure window shattering
+    /// </summary>
+    public static readonly CVarDef<float> DeltaPReinforcedPlasma =
+        CVarDef.Create("atmos.reinforced_plasma_window_deltaP_threshold", 300000f, CVar.SERVER);
+
+    public static readonly CVarDef<float> DeltaPReinforced =
+        CVarDef.Create("atmos.reinforced_window_deltaP_threshold", 80000f, CVar.SERVER);
+}


### PR DESCRIPTION
Добавлены CVars и система для настройки значений DeltaP укрепленных и плазменных окон. 

Повышены значения DeltaP для укрепленного и укрепленного плазменного окон для возвращения варки в камерах.