### PR TITLE
Замена конца раунда у ревы на Эпсилон + эвак 20 минут

### DIFF
--- a/Content.Server/GameTicking/Rules/Components/RevolutionaryRuleComponent.cs
+++ b/Content.Server/GameTicking/Rules/Components/RevolutionaryRuleComponent.cs
@@ -26,5 +26,6 @@ public sealed partial class RevolutionaryRuleComponent : Component
     /// The time it takes after the last head is killed for the shuttle to arrive.
     /// </summary>
     [DataField, ViewVariables(VVAccess.ReadWrite)]
-    public TimeSpan ShuttleCallTime = TimeSpan.FromMinutes(5);
+    public TimeSpan ShuttleCallTime = TimeSpan.FromMinutes(20); // Fish-Edit
+
 }

--- a/Content.Server/GameTicking/Rules/RevolutionaryRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/RevolutionaryRuleSystem.cs
@@ -103,7 +103,9 @@ public sealed class RevolutionaryRuleSystem : GameRuleSystem<RevolutionaryRuleCo
                 {
                     _alertLevel.SetLevel(station, "epsilon", true, true, true);
                 }
-                _roundEnd.EndRound();
+                // Fish-Edit-Start
+                _roundEnd.RequestRoundEnd(component.ShuttleCallTime, uid, true, cantRecall: true);
+                // Fish-Edit-End
                 //  Sunrise-Edit-End
                 GameTicker.EndGameRule(uid, gameRule);
             }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

<!-- Текст в стрелочках является комментариями - они не будут видны в вашем PR. -->

## Кратное описание
<!-- Что вы предлагаете изменить с помощью своего PR? -->

## По какой причине
<!-- В чём причина добавления этих изменений? Ссылки на Дискуссии, а так-же Баг-Репорты указывать здесь. Пожалуйста опишите как это изменит игровой баланс. -->

## Медиа(Видео/Скриншоты)
<!--
Если ваш PR содержит внутриигровые изменения вы обязаны предоставить скриншоты/видео изменений.
-->

**Changelog**


:cl: Kaiten

- tweak: Форсируемый конец раунда при победе ревы заменяется на просто эпсилон + форсированный эвак на 20 минут, чтобы рева выживала против ОБР.

