### PR TITLE
Возращения всех доступов членов центрального командования

### DIFF
--- a/Resources/Prototypes/_Fish/Roles/Jobs/Blueshield/representative_blueshield.yml
+++ b/Resources/Prototypes/_Fish/Roles/Jobs/Blueshield/representative_blueshield.yml
@@ -20,8 +20,6 @@
   #Fish-start
   accessGroups:
   - AllAccess
-  access:
-  - CentralCommand
   # Fish-End
   special:
    - !type:AddImplantSpecial

--- a/Resources/Prototypes/_Fish/Roles/Jobs/Blueshield/representative_blueshield.yml
+++ b/Resources/Prototypes/_Fish/Roles/Jobs/Blueshield/representative_blueshield.yml
@@ -17,28 +17,12 @@
 
   supervisors: job-supervisors-representative
   canBeAntag: false
+  #Fish-start
+  accessGroups:
+  - AllAccess
   access:
-   - Command
-   - Bar
-   - Service
-   - Maintenance
-   - Janitor
-   - Theatre
-   - Kitchen
-   - Chapel
-   - Hydroponics
-   - External
-   - Chemistry
-   - Engineering
-   - Research
-   - Salvage
-   - Cargo
-   - Atmospherics
-   - Cargo
-   - Medical
-   - BlueShield
-   - BlueShieldEnsign
-   - Ntrep
+  - CentralCommand
+  # Fish-End
   special:
    - !type:AddImplantSpecial
      implants: [ MindShieldImplant ]

--- a/Resources/Prototypes/_Sunrise/Roles/Jobs/Blueshield/blueshield_ensign.yml
+++ b/Resources/Prototypes/_Sunrise/Roles/Jobs/Blueshield/blueshield_ensign.yml
@@ -19,8 +19,6 @@
   #Fish-start
   accessGroups:
   - AllAccess
-  access:
-  - CentralCommand
   # Fish-End
   special:
     - !type:AddImplantSpecial

--- a/Resources/Prototypes/_Sunrise/Roles/Jobs/Blueshield/blueshield_ensign.yml
+++ b/Resources/Prototypes/_Sunrise/Roles/Jobs/Blueshield/blueshield_ensign.yml
@@ -16,26 +16,12 @@
   icon: JobIconBlueShield
   supervisors: job-supervisors-centcom
   canBeAntag: false
+  #Fish-start
+  accessGroups:
+  - AllAccess
   access:
-    - Command
-    - Bar
-    - Service
-    - Maintenance
-    - Janitor
-    - Theatre
-    - Kitchen
-    - Chapel
-    - Hydroponics
-    - External
-    - Chemistry
-    - Engineering
-    - Research
-    - Salvage
-    - Cargo
-    - Atmospherics
-    - Medical
-    - BlueShield
-    - BlueShieldEnsign
+  - CentralCommand
+  # Fish-End
   special:
     - !type:AddImplantSpecial
       implants: [ MindShieldImplant ]

--- a/Resources/Prototypes/_Sunrise/Roles/Jobs/Command/nanotrasen_representative.yml
+++ b/Resources/Prototypes/_Sunrise/Roles/Jobs/Command/nanotrasen_representative.yml
@@ -13,31 +13,12 @@
   canBeAntag: false
   alternativeTitles:
   - job-alt-title-nt-diplomat
+  #Fish-start
+  accessGroups:
+  - AllAccess
   access:
-    - Cryogenics
-    - Lawyer
-    - Command
-    - Bar
-    - Service
-    - Maintenance
-    - Janitor
-    - Theatre
-    - Kitchen
-    - Chapel
-    - Hydroponics
-    - External
-    - Chemistry
-    - Engineering
-    - Research
-    - Detective
-    - Salvage
-    - Security
-    - Brig
-    - Cargo
-    - Atmospherics
-    - Cargo
-    - Medical
-    - Ntrep
+  - CentralCommand
+  #Fish-end
   special:
     - !type:AddImplantSpecial
       implants: [ MindShieldImplant, TrackingImplant, DeathRattleImplantBlueShield ]

--- a/Resources/Prototypes/_Sunrise/Roles/Jobs/Command/nanotrasen_representative.yml
+++ b/Resources/Prototypes/_Sunrise/Roles/Jobs/Command/nanotrasen_representative.yml
@@ -16,8 +16,6 @@
   #Fish-start
   accessGroups:
   - AllAccess
-  access:
-  - CentralCommand
   #Fish-end
   special:
     - !type:AddImplantSpecial


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

<!-- Текст в стрелочках является комментариями - они не будут видны в вашем PR. -->

## Кратное описание
<!-- Что вы предлагаете изменить с помощью своего PR? -->
Возращения всех доступов членов центрального командования.
## По какой причине
<!-- В чём причина добавления этих изменений? Ссылки на Дискуссии, а так-же Баг-Репорты указывать здесь. Пожалуйста опишите как это изменит игровой баланс. -->
ПНТ, КСЩ, оперу СЩ по срп обязаны иметь полный доступ на объекты, а также ПНТ не может исполнять срп, пример на врио, из-за отсутствия доступов.
## Медиа(Видео/Скриншоты)
<!--
Если ваш PR содержит внутриигровые изменения вы обязаны предоставить скриншоты/видео изменений.
-->

**Changelog**
<!--
Если нужно чтобы игроки узнали об изменениях сделанных в данном PR, укажите их используя шаблон вне комментария.
Кратко и информативно.

:cl: VigersRay
- add: Добавлено веселье.
- remove: Удалено веселье.
- tweak: Изменено веселье.
- fix: Исправлено веселье.
-->
:cl: Fynex_x
- add: Добавлен полный доступ Оперу СЩ
- tweak: Возвращение полного доступа ПНТ и КСЩ