### PR TITLE
Kitsune: полувульпа-скафы — видимый хвост в EVA/Hardsuit

### DIFF
--- a/Resources/Prototypes/_Fish/Entities/Mobs/kitsune.yml
+++ b/Resources/Prototypes/_Fish/Entities/Mobs/kitsune.yml
@@ -3,8 +3,6 @@
   id: MacKitsune
 
   components:
-  # Fish-edit: «полувульпа»-скафы — голова/тело как у Human (как Inventory.speciesId: human у Vulpkanin),
-  # хвост не входит в hideLayersOnEquip, чтобы EVA/Hardsuit HideLayerClothing его не скрывал.
   - type: HumanoidAppearance
     species: Kitsune
     hideLayersOnEquip:
@@ -12,7 +10,6 @@
     - Snout
     - HeadTop
     - Special
-  # Fish-edit: тот же clothing species path, что у Vulpkanin — human-спрайты тела, без head-vulpkanin.
   - type: Inventory
     speciesId: human
   - type: Damageable

--- a/Resources/Prototypes/_Fish/Entities/Mobs/kitsune.yml
+++ b/Resources/Prototypes/_Fish/Entities/Mobs/kitsune.yml
@@ -3,6 +3,18 @@
   id: MacKitsune
 
   components:
+  # Fish-edit: «полувульпа»-скафы — голова/тело как у Human (как Inventory.speciesId: human у Vulpkanin),
+  # хвост не входит в hideLayersOnEquip, чтобы EVA/Hardsuit HideLayerClothing его не скрывал.
+  - type: HumanoidAppearance
+    species: Kitsune
+    hideLayersOnEquip:
+    - Hair
+    - Snout
+    - HeadTop
+    - Special
+  # Fish-edit: тот же clothing species path, что у Vulpkanin — human-спрайты тела, без head-vulpkanin.
+  - type: Inventory
+    speciesId: human
   - type: Damageable
     damageModifierSet: Kitsune
   - type: KitsuneTransform


### PR DESCRIPTION
## Summary
- Kitsune используют тот же путь одежды, что и Vulpkanin: спрайты тела/шлема human через `Inventory.speciesId: human`, поэтому snout-варианты `head-vulpkanin` не выбираются.
- `Tail` убран из `hideLayersOnEquip` (как у Vulpkanin/Felinid), поэтому EVA/Hardsuit через `HideLayerClothing` больше не скрывают лисий хвост Kitsune.
- Поведение Human и Vulpkanin не изменено; без дублирования clothing YAML и без новых визуализаторов.

## Test plan
- [ ] Заспавнить Human, Vulpkanin, Kitsune
- [ ] Надеть несколько EVA/Hardsuit с поддержкой `head-vulpkanin`
- [ ] Убедиться, что Human выглядит как раньше
- [ ] Убедиться, что Vulpkanin без изменений (хвост виден, displacements на месте)
- [ ] Убедиться, что у Kitsune: human-шлем/тело, хвост остаётся видимым, уши следуют существующим правилам `hideLayersOnEquip`
- [ ] YAMLLinter чистый