### PR TITLE
[MAPS] Удаление пуна с карт

### DIFF
--- a/Resources/Maps/_Fish/Station/Case.yml
+++ b/Resources/Maps/_Fish/Station/Case.yml
@@ -112938,13 +112938,6 @@ entities:
     - type: Transform
       pos: 38.5,-0.5
       parent: 2
-- proto: SpawnMobMonkeyPunpun
-  entities:
-  - uid: 14897
-    components:
-    - type: Transform
-      pos: 19.5,54.5
-      parent: 2
 - proto: SpawnMobMouse
   entities:
   - uid: 1425

--- a/Resources/Maps/_Fish/Station/bagel.yml
+++ b/Resources/Maps/_Fish/Station/bagel.yml
@@ -160494,13 +160494,6 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 25.5,-28.5
       parent: 2
-- proto: SpawnMobMonkeyPunpun
-  entities:
-  - uid: 21482
-    components:
-    - type: Transform
-      pos: 10.5,-36.5
-      parent: 2
 - proto: SpawnMobMouse
   entities:
   - uid: 21483

--- a/Resources/Maps/_Fish/Station/barratry.yml
+++ b/Resources/Maps/_Fish/Station/barratry.yml
@@ -91773,13 +91773,6 @@ entities:
     - type: Transform
       pos: -46.5,59.5
       parent: 2
-- proto: SpawnMobMonkeyPunpun
-  entities:
-  - uid: 13184
-    components:
-    - type: Transform
-      pos: -31.5,37.5
-      parent: 2
 - proto: SpawnMobMouse
   entities:
   - uid: 13185

--- a/Resources/Maps/_Fish/Station/box.yml
+++ b/Resources/Maps/_Fish/Station/box.yml
@@ -202840,13 +202840,6 @@ entities:
     - type: Transform
       pos: 26.5,-24.5
       parent: 2
-- proto: SpawnMobMonkeyPunpun
-  entities:
-  - uid: 27537
-    components:
-    - type: Transform
-      pos: 24.5,-1.5
-      parent: 2
 - proto: SpawnMobMouse
   entities:
   - uid: 27538

--- a/Resources/Maps/_Fish/Station/delta.yml
+++ b/Resources/Maps/_Fish/Station/delta.yml
@@ -245289,13 +245289,6 @@ entities:
     - type: Transform
       pos: 46.5,36.5
       parent: 2
-- proto: SpawnMobMonkeyPunpun
-  entities:
-  - uid: 34023
-    components:
-    - type: Transform
-      pos: -7.5,39.5
-      parent: 2
 - proto: SpawnMobMouse
   entities:
   - uid: 34024

--- a/Resources/Maps/_Fish/Station/oasis.yml
+++ b/Resources/Maps/_Fish/Station/oasis.yml
@@ -186746,13 +186746,6 @@ entities:
     - type: Transform
       pos: -25.5,-20.5
       parent: 2
-- proto: SpawnMobMonkeyPunpun
-  entities:
-  - uid: 32765
-    components:
-    - type: Transform
-      pos: -19.5,8.5
-      parent: 2
 - proto: SpawnMobMouse
   entities:
   - uid: 13677

--- a/Resources/Maps/_Fish/Station/packed.yml
+++ b/Resources/Maps/_Fish/Station/packed.yml
@@ -14289,7 +14289,7 @@ entities:
       rot: 3.141592653589793 rad
       pos: -73.5,-25.5
       parent: 2
-- proto: AirlockExternalGlassSecurityShuttle
+- proto: AirlockExternalGlassFishSecurityShuttle
   entities:
   - uid: 625
     components:
@@ -103364,13 +103364,6 @@ entities:
     components:
     - type: Transform
       pos: 58.5,-2.5
-      parent: 2
-- proto: SpawnMobMonkeyPunpun
-  entities:
-  - uid: 14438
-    components:
-    - type: Transform
-      pos: 39.5,-4.5
       parent: 2
 - proto: SpawnMobMoproach
   entities:

--- a/Resources/Maps/_Fish/Station/plasma.yml
+++ b/Resources/Maps/_Fish/Station/plasma.yml
@@ -152479,13 +152479,6 @@ entities:
     - type: Transform
       pos: -26.5,-19.5
       parent: 2
-- proto: SpawnMobMonkeyPunpun
-  entities:
-  - uid: 22800
-    components:
-    - type: Transform
-      pos: -68.5,-26.5
-      parent: 2
 - proto: SpawnMobParrot
   entities:
   - uid: 22801

--- a/Resources/Maps/_Fish/Station/snowball.yml
+++ b/Resources/Maps/_Fish/Station/snowball.yml
@@ -116463,13 +116463,6 @@ entities:
     - type: Transform
       pos: 66.5,46.5
       parent: 2
-- proto: SpawnMobMonkeyPunpun
-  entities:
-  - uid: 14233
-    components:
-    - type: Transform
-      pos: 50.5,71.5
-      parent: 2
 - proto: SpawnMobMouse
   entities:
   - uid: 14234

--- a/Resources/Maps/_Fish/Station/suharik.yml
+++ b/Resources/Maps/_Fish/Station/suharik.yml
@@ -271591,13 +271591,6 @@ entities:
     - type: Transform
       pos: -3.5,13.5
       parent: 33049
-- proto: SpawnMobMonkeyPunpun
-  entities:
-  - uid: 20605
-    components:
-    - type: Transform
-      pos: -18.5,42.5
-      parent: 2
 - proto: SpawnMobMouse
   entities:
   - uid: 25303


### PR DESCRIPTION
## Краткое описание
Удаление пуна с карт, т.к. любят его брать и ползать по венте обкрадывая сб и ком.
Фикс стыковочного шлюза сб на пакеде.

