### PR TITLE
fix(obr): баланс карго на консоли покупки ОБР на боевых картах

### DIFF
--- a/Content.IntegrationTests/Tests/_Fish/ObrCall/ObrCallIntegrationTests.cs
+++ b/Content.IntegrationTests/Tests/_Fish/ObrCall/ObrCallIntegrationTests.cs
@@ -17,6 +17,7 @@ public sealed class ObrCallIntegrationTests
     private static readonly EntProtoId AmberRuleId = "FishObrShuttleAmber";
     private static readonly EntProtoId MissionRoleId = "MindRoleObrMission";
     private static readonly ProtoId<ObrCallSettingsPrototype> SettingsId = "DefaultObrCallSettings";
+    private static readonly EntProtoId StandardStationId = "StandardNanotrasenStation";
 
     [Test]
     public async Task PrototypesExistAndGammaNotOnStationList()
@@ -46,6 +47,22 @@ public sealed class ObrCallIntegrationTests
             Assert.That(proto.Index(AmberId).StationCost, Is.EqualTo(100000));
             Assert.That(proto.Index(RedId).StationCost, Is.EqualTo(200000));
             Assert.That(proto.Index(CburnId).StationCost, Is.EqualTo(200000));
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    [Test]
+    public async Task StandardNanotrasenStation_HasMainStationAndCentCommLink()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+
+        await server.WaitAssertion(() =>
+        {
+            var stationProto = server.ProtoMan.Index(StandardStationId);
+            Assert.That(stationProto.Components.ContainsKey("MainStation"), Is.True);
+            Assert.That(stationProto.Components.ContainsKey("StationCentComm"), Is.True);
         });
 
         await pair.CleanReturnAsync();

--- a/Content.Server/_Fish/ObrCall/ObrCallSystem.cs
+++ b/Content.Server/_Fish/ObrCall/ObrCallSystem.cs
@@ -9,7 +9,6 @@ using Content.Server.Roles;
 using Content.Server.Shuttles.Components;
 using Content.Server.Shuttles.Systems;
 using Content.Server.Station.Systems;
-using Content.Server._Sunrise.StationCentComm;
 using Content.Server._Sunrise.Storyteller.Components;
 using Content.Shared._Fish.ObrCall;
 using Content.Shared.Cargo.Prototypes;
@@ -303,7 +302,7 @@ public sealed partial class ObrCallSystem : EntitySystem
 
     /// <summary>
     /// Для покупки — основная станция с банковским счётом (как у cargo console / storyteller metrics).
-    /// Для ЦК — основная игровая станция без CentComm.
+    /// Для ЦК — основная игровая станция (MainStation), даже если у неё есть привязка CentComm-шаттла.
     /// </summary>
     private bool TryGetTargetStation(EntityUid console, bool purchaseMode, out EntityUid station)
     {
@@ -329,13 +328,12 @@ public sealed partial class ObrCallSystem : EntitySystem
     {
         station = EntityUid.Invalid;
 
-        if (HasComp<StationCentCommComponent>(candidate))
-            return false;
-
         if (!HasComp<StationDataComponent>(candidate))
             return false;
 
         // Sunrise: баланс и метрики считаются только по MainStation.
+        // Не фильтровать StationCentComm: он есть у StandardNanotrasenStation (привязка шаттла ЦК),
+        // а не только у отдельной карты NanotrasenCentralCommand.
         if (!HasComp<MainStationComponent>(candidate))
             return false;
 

--- a/Resources/Changelog/ChangelogFish.yml
+++ b/Resources/Changelog/ChangelogFish.yml
@@ -1,5 +1,11 @@
 ﻿Entries:
 - author: Pifagor
+  time: '2026-08-22T09:00:00.0000000+00:00'
+  changes:
+  - type: Fix
+    message: Консоль покупки ОБР снова показывает баланс карго на боевых картах (StandardNanotrasenStation).
+    id: 24
+- author: Pifagor
   time: '2026-08-19T16:50:00.0000000+00:00'
   changes:
   - type: Fix


### PR DESCRIPTION
## Summary
- Убран фильтр по `StationCentCommComponent` при выборе станции для консоли ОБР.
- `StandardNanotrasenStation` (все боевые карты Fish) имеет и `MainStation`, и `StationCentComm` — старый фильтр отбрасывал основную станцию, поэтому баланс всегда был 0.
- Добавлен интеграционный тест, фиксирующий этот инвариант прототипа.

## Test plan
- [x] `dotnet build Content.Server` — OK
- [x] `ObrCallIntegrationTests` (2/2) — OK
- [ ] Открыть `ComputerObrStationConsole` на боевой карте (не DevStation) и проверить, что баланс карго совпадает с cargo console

Made with [Cursor](https://cursor.com)